### PR TITLE
Don't delete characters in password

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -90,7 +90,7 @@
   register: jenkins_podname
 -
   name: "Get jenkins password"
-  shell: 'oc env pod {{ jenkins_podname }} --list | grep JENKINS_PASSWORD | tr -d JENKINS_PASSWORD='
+  shell: "oc env pod {{ jenkins_podname.stdout }} --list | grep JENKINS_PASSWORD | awk -F '=' '{ print $2 }'"
   register: jenkins_password
 
 -


### PR DESCRIPTION
Currently we are using tr to remove the JENKINS_PASSWORD= section
from our oc & grep result. However tr's functionality is as follows.

echo "aabbccdd" | tr -d b # Returns aaccdd

So we may delete characters in a password if they contain any of the
characters included in JENKINS_PASSWORD=.

This uses awk instead.