### PR TITLE
add check for android-sdk command

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -92,7 +92,7 @@
   command: "oc rsh --namespace={{ project_name }} {{ android_sdk_podname }} androidctl sync /opt/tools/{{ config_file }}"
   register: rsh_cmd
   become: true
-  failed_when: "'Traceback' in rsh_cmd.stdout"
+  failed_when: "'Traceback' in rsh_cmd.stdout or 'Common Arguments' in rsh_cmd.stdout"
 
 - debug:
     msg: "Licences are up to date. Continuing...."


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-16535

The check for 'Common Arguments' will catch if the sdkmanager command is formatted incorrectly. i.e. if there is some problem with the way we call the sdkmanager from within androidctl.
If it is formatted incorrectly it outputs the help manual which contains this check.
This text is not included in the Licence text as we don't want it to fail by finding this value inside the Licence text.
