### PR TITLE
AGDIGGER-123 Download Apple's WWDR certificate during OSX provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+sample-build-playbook.retry

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The playbook executes the following steps for you:
 - Installs Jenkins
 - Configures Jenkins
 - Installs AndroidSDK to a PV
-- Installs iOS
+- Configures an OSX node
 
 
 ## License

--- a/provision-osx/README.md
+++ b/provision-osx/README.md
@@ -6,6 +6,7 @@ Provision Jenkins node for the build farm. This role performs a few tasks, these
 * [Install RVM and Ruby](#install-homebrew)
 * [Install NVM and Node](#install-rvm-and-ruby)
 * [Install Xcode](#install-xcode)
+* [Download certs](#download-certs)
 
 ## Prerequisites
 * SSH access as a user with sudo permissions.
@@ -87,6 +88,13 @@ Ansible job.
 * `xcode_install_session_token` - Apple Developer Account auth cookie from `fastlane spaceauth` command (For accounts with 2FA enabled).
 * `xcode_versions` - A list of Xcode versions to install. These may take over 30 minutes each to install.
 
+## Download certs
+Downloads some required certificates into the node. Right now, the only required certificate is Apple's WWDR certificate.
+This certificate will be downloaded into the user's home directory.
+ 
+### Options:
+* `apple_wwdr_cert_url` - Apple WWDR certificate URL. Defaults to Apple's official URL
+* `apple_wwdr_cert_file_name` - Output file name of the downloaded file. Defaults to `AppleWWDRCA.cer`.
 
 ## Other options
 * `remote_tmp_dir` - A directory where downloaded scripts and other miscellaneous files can be stored for the duration of the job.

--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -44,3 +44,6 @@ xcode_install_user:
 xcode_install_password:
 xcode_versions:
 - 8
+
+apple_wwdr_cert_url: http://developer.apple.com/certificationauthority/AppleWWDRCA.cer
+apple_wwdr_cert_file_name: AppleWWDRCA.cer

--- a/provision-osx/tasks/download_certs.yml
+++ b/provision-osx/tasks/download_certs.yml
@@ -1,0 +1,10 @@
+---
+
+-
+  name: Download Apple WWDR certs
+  get_url:
+    url: "{{ apple_wwdr_cert_url }}"
+    dest: "{{ ansible_env.HOME }}/{{ apple_wwdr_cert_file_name }}"
+  environment:
+    http_proxy: "{{ proxy_url | default('') }}"
+    https_proxy: "{{ proxy_url | default('') }}"

--- a/provision-osx/tasks/main.yml
+++ b/provision-osx/tasks/main.yml
@@ -4,7 +4,7 @@
   tags: osx_install_homebrew
   
 - include: install_ruby.yml
-  tags: osx_install_homebrew
+  tags: osx_install_ruby
 
 - include: install_nodejs.yml
   tags: osx_install_nodejs

--- a/provision-osx/tasks/main.yml
+++ b/provision-osx/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
 
 - include: install_homebrew.yml
+  tags: osx_install_homebrew
+  
 - include: install_ruby.yml
+  tags: osx_install_homebrew
+
 - include: install_nodejs.yml
+  tags: osx_install_nodejs
+
 - include: install_xcode.yml
+  tags: osx_install_xcode
+
+- include: download_certs.yml
+  tags: osx_download_certs


### PR DESCRIPTION
See https://issues.jboss.org/browse/AGDIGGER-123

How to verify:
* Have an OSX machine with SSH enabled. e.g. your local Mac
* Change `cluster-up-example` inventory file like this:
```
[macos]
127.0.0.1
```
* Run this:
```
ansible-playbook -i cluster-up-example sample-build-playbook.yml --tags=osx_download_certs
```
* In case of login problems, add `--ask-pass` flag to the command above. It will ask the password of the OSX user (by default, it the user named `jenkins`) 
