### PR TITLE
AGDIGGER-125 Configure container cap option in K8s plugin

### DIFF
--- a/configure-buildfarm/defaults/main.yml
+++ b/configure-buildfarm/defaults/main.yml
@@ -4,6 +4,9 @@ project_name: jenkins
 buildfarm_version: "2.0"
 
 jenkins_home: /var/lib/jenkins
+
+concurrent_android_builds: 10
+
 jenkins_plugins:
   -
     name: "ssh-slaves"

--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -101,17 +101,17 @@
      - config
 
 -
-  name: "Create podtemplate update Groovy script from template"
+  name: "Create Kubernetes plugin config update Groovy script from template"
   template:
-    src: podtemplate-config.j2
-    dest: "/tmp/podtemplate-config.groovy"
+    src: kubernetes-plugin-config.j2
+    dest: "/tmp/kubernetes-plugin-config.groovy"
     force: yes
   connection: local
   tags:
     - config
 
-- name: "Configure pod template"
-  shell: "java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy  /tmp/podtemplate-config.groovy"
+- name: "Configure Kubernetes plugin"
+  shell: "java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy  /tmp/kubernetes-plugin-config.groovy"
   connection: local
   register: output
   failed_when: output.stderr != ''

--- a/configure-buildfarm/templates/kubernetes-plugin-config.j2
+++ b/configure-buildfarm/templates/kubernetes-plugin-config.j2
@@ -22,6 +22,7 @@ def HTTPS_PROXY_ENVVAR_NAME = "HTTPS_PROXY"
 def GRADLE_OPTS_ENVVAR_NAME = "GRADLE_OPTS"
 def PROXY_URL="{{ proxy_url | default('') }}"
 def GRADLE_OPTS="{{ proxy_gradle_opts | default('') }}"
+def CONTAINER_CAP = {{ concurrent_android_builds }}
 
 // get the jenkins instance
 def instance = Jenkins.getInstance()
@@ -29,6 +30,11 @@ def instance = Jenkins.getInstance()
 // we know that the PodTemplates are set in the first element
 def templates =  instance.clouds.templates[0]
 def cloud = instance.clouds
+
+// we know that cloud[0] is the Kubernetes cloud we're interested in.
+// do some configuration on it before configuring the pod templates.
+cloud[0].containerCap = CONTAINER_CAP
+
 def existingPodTemplate = false
 
 // check to see if we have a pod set with name=android

--- a/vars/buildfarm.yml
+++ b/vars/buildfarm.yml
@@ -26,3 +26,5 @@ deployments:
       image: "docker.io/aerogear/android-sdk:dev"
 
 macos_user: jenkins
+
+concurrent_android_builds: 5


### PR DESCRIPTION
How to verify:

```
ansible-playbook -i cluster-up-example sample-build-playbook.yml 
```

You might have problems with SSL (if really using local cluster). In that case, either add SSL cert of to Java's trusted certs or modify the `java -jar jenkins.cli.jar ...` in the playbook to use `-noCertificateCheck` flag.

You might also have "ERROR: anonymous is missing the Overall/Read permission" error. In that case change your private key with a no-password-protected one temporarily or modify the `java -jar jenkins.cli.jar ...` in the playbook to use `-i <new no-password private key>` flag.