### PR TITLE
 🐛 make sure the HTTP_PROXY and HTTPS_PROXY is added to the mac slave

### DIFF
--- a/provision-osx/templates/create-node.xml.j2
+++ b/provision-osx/templates/create-node.xml.j2
@@ -20,7 +20,11 @@
             <default>
               <comparator class="hudson.util.CaseInsensitiveComparator"/>
             </default>
+            {% if proxy_url is defined and proxy_url != '' %}
+            <int>6</int>
+            {% else %}
             <int>4</int>
+            {% endif %}
             <string>BASH</string>
             <string>{{ buildfarm_env_bash.stdout }}</string>
             <string>CI</string>
@@ -29,6 +33,12 @@
             <string>{{ buildfarm_env_gem.stdout }}</string>
             <string>PATH</string>
             <string>{{ buildfarm_env_path.stdout }}</string>
+            {% if proxy_url is defined and proxy_url != '' %}
+            <string>HTTP_PROXY</string>
+            <string>{{ proxy_url }}</string>
+            <string>HTTPS_PROXY</string>
+            <string>{{ proxy_url }}</string>
+            {% endif %}
           </tree-map>
         </envVars>
       </hudson.slaves.EnvironmentVariablesNodeProperty>


### PR DESCRIPTION
 template if proxy_url is set

Noticed that those env vars are not set on the mac slave. I think they should be set.

@aidenkeating @odra do you guys think we should add those env vars?