### PR TITLE
Ignore android-sdk-deploy pod when getting full name of android-sdk pod

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -51,6 +51,7 @@
 -
   name: "Get the Android SDK pod name"
   shell: "oc get pods --namespace={{ project_name }} | grep android-sdk | grep -v deploy | awk '{print$1}'"
+  failed_when: output.stdout == ""
   register: output
 
 -

--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -50,7 +50,7 @@
 
 -
   name: "Get the Android SDK pod name"
-  shell: "oc get pods --namespace={{ project_name }} | grep android-sdk | awk '{print$1}'"
+  shell: "oc get pods --namespace={{ project_name }} | grep android-sdk | grep -v deploy | awk '{print$1}'"
   register: output
 
 -


### PR DESCRIPTION
This fix is for following error:

> TASK [android-sdk : Install the Android SDK] ***************************************************************************************************************************************
> fatal: [osm1-master1.feedhenry.net]: FAILED! => {"changed": true, "cmd": ["oc", "rsh", "--namespace=aerogear-digger", "android-sdk-1-deploy", "android-sdk-1-owjx9", "androidctl", "sdk", "install"], "delta": "0:00:00.170020", "end": "2017-07-18 12:08:32.544695", "failed": true, "rc": 1, "start": "2017-07-18 12:08:32.374675", "stderr": "Error from server: pods \"android-sdk-1-deploy\" not found", "stderr_lines": ["Error from server: pods \"android-sdk-1-deploy\" not found"], "stdout": "", "stdout_lines": []}

Notice two pod names in there - "android-sdk-1-deploy" and "android-sdk-1-owjx9".
