### PR TITLE
AGDIGGER-125 Fix terminal encoding - CocoaPods requirement

### DIFF
--- a/provision-osx/tasks/install_nodejs.yml
+++ b/provision-osx/tasks/install_nodejs.yml
@@ -41,5 +41,5 @@
 
 -
   lineinfile:
-    path: ~/.bash_profile
+    dest: ~/.bash_profile
     line: source "$HOME/.bashrc"

--- a/provision-osx/tasks/install_ruby.yml
+++ b/provision-osx/tasks/install_ruby.yml
@@ -18,7 +18,7 @@
 
 -
   name: Retrieve rvm install script
-  get_url: 
+  get_url:
     url: "{{rvm_install_url}}"
     dest: "{{remote_tmp_dir}}/{{rvm_install_file_name}}"
   register: rvm_prerequisites
@@ -33,7 +33,7 @@
     http_proxy: "{{ proxy_url | default('') }}"
     https_proxy: "{{ proxy_url | default('') }}"
 
-- 
+-
   name: Install ruby
   shell: "source ~/.bash_profile && rvm install {{ ruby_version }}"
   args:
@@ -57,7 +57,16 @@
     http_proxy: "{{ proxy_url | default('') }}"
     https_proxy: "{{ proxy_url | default('') }}"
 
-- 
+-
+  # CocoaPods require the terminal to use UTF-8 encoding
+  # if we don't have this setting, doing "pod install" on
+  # some projects fail (e.g. https://github.com/feedhenry-templates/helloworld-ios-swift)
+  name: Configure terminal encoding for CocoaPods
+  lineinfile:
+    dest: ~/.bashrc
+    line: 'export LANG=en_US.UTF-8'
+
+-
   name: Install gem packages
   shell: "source ~/.bash_profile && gem install --no-ri --no-rdoc {{item.name}} -v {{ item.version | default('\"\"') }}"
   args:


### PR DESCRIPTION
See JIRA : https://issues.jboss.org/browse/AGDIGGER-129

## How to verify:

* Provision an OSX node

* Restart Jenkins' OSX node so that it picks up the new terminal encoding (e.g. https://jenkins-aerogear-digger.apps.127.0.0.1.nip.io/computer/ --> then disconnect and connect)

* Create a new Jenkins job and use this pipeline (modify pod binary path if necessary)
```
node("ios"){
    stage("f"){
        sh "whoami"
        sh "pwd"
        sh "ls -laht"
        git "https://github.com/feedhenry-templates/helloworld-ios-swift.git"
        sh "/usr/local/bin/pod install"
    }
}
```

There should be no errors.

BTW, I used this command to provision OSX machine: 
```
ansible-playbook -i cluster-up-example sample-build-playbook.yml --tags=provision-osx --ask-pass -e ansible_user=jenkins
```