### PR TITLE
add bash_env to config

### DIFF
--- a/configure-buildfarm/templates/kubernetes-plugin-config.j2
+++ b/configure-buildfarm/templates/kubernetes-plugin-config.j2
@@ -23,6 +23,8 @@ def GRADLE_OPTS_ENVVAR_NAME = "GRADLE_OPTS"
 def PROXY_URL="{{ proxy_url | default('') }}"
 def GRADLE_OPTS="{{ proxy_gradle_opts | default('') }}"
 def CONTAINER_CAP = {{ concurrent_android_builds }}
+def BASH_ENVAR_NAME = "BASH_ENV"
+def BASH_ENVVAR = "/etc/profile"
 
 // get the jenkins instance
 def instance = Jenkins.getInstance()
@@ -101,9 +103,12 @@ if (existingPodTemplate) {
     def gradleEnvVar = new PodEnvVar(GRADLE_OPTS_ENVVAR_NAME, GRADLE_OPTS)
     podEnvVarList.add(gradleEnvVar)
   }
-    // now setup pod envars
+
   def pe = new PodEnvVar(ANDROID_HOME_ENVVAR_NAME,ANDROID_HOME_ENVVAR_VALUE)
   podEnvVarList.add(pe)
+
+  def bashEnvVar = new PodEnvVar(BASH_ENVAR_NAME,BASH_ENVVAR)
+  podEnvVarList.add(bashEnvVar)
 
 }
 


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-16812

**Changes**
Adding BASH_ENV configuration to the configure-buildfarm role in digger installer.

**Verification**
- On vagrant
- Delete the Kubernetes Pod in Jenkins
- Run command:
```
ansible-playbook -i ../rhmap-ansible/inventories/engineering/vagrant/vagrant-host sample-build-playbook.yml --tags=configure-buildfarm -e "project_name=digger"
```
- Re run command to see that the environment variable addition is idempotent.

_Expected Results_
- BASH_ENV should be configured in the Kubernetes Pod.
- re run of the command should not create additional copies of the variable.