### PR TITLE
cleanup meta data, login dependency

### DIFF
--- a/android-sdk/meta/main.yml
+++ b/android-sdk/meta/main.yml
@@ -3,6 +3,7 @@ galaxy_info:
   author: AeroGear
   company: AeroGear
   description: "Role for deploying the AeroGear digger android-sdk pod"
+  issue_tracker_url: https://issues.jboss.org/projects/AGDIGGER/issues
   license: "license (Apache 2)"
   min_ansible_version: "2.2.0"
   platforms:
@@ -11,17 +12,8 @@ galaxy_info:
       version:
         - 25
 
-  galaxy_tags: []
-    # List tags for your role here, one per line. A tag is
-    # a keyword that describes and categorizes the role.
-    # Users find roles by searching for tags. Be sure to
-    # remove the '[]' above if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of
-    # alphanumeric characters. Maximum 20 tags per role.
+  galaxy_tags:
+    - digger
 
-dependencies: []
-  # List your role dependencies here, one per line.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
-
+dependencies:
+  - { role: login }

--- a/configure-buildfarm/meta/main.yml
+++ b/configure-buildfarm/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: AeroGear
   company: AeroGear
-  description: "Roles for deploying the AeroGear digger"
+  description: "Role for Jenkins configuration in digger"
   issue_tracker_url: https://issues.jboss.org/projects/AGDIGGER/issues
   license: "license (Apache 2)"
   min_ansible_version: "2.2.0"
@@ -11,3 +11,9 @@ galaxy_info:
       name: fedora
       version:
         - 25
+
+  galaxy_tags:
+    - digger
+
+dependencies: 
+  - { role: login }

--- a/deploy-jenkins/meta/main.yml
+++ b/deploy-jenkins/meta/main.yml
@@ -1,4 +1,19 @@
 ---
+galaxy_info:
+  author: AeroGear
+  company: AeroGear
+  description: "Role for Installing Jenkins in digger"
+  issue_tracker_url: https://issues.jboss.org/projects/AGDIGGER/issues
+  license: "license (Apache 2)"
+  min_ansible_version: "2.2.0"
+  platforms:
+    -
+      name: fedora
+      version:
+        - 25
+
+  galaxy_tags:
+    - digger
 
 dependencies:
-  - { role: login, tags: login}
+  - { role: login }

--- a/deploy-nagios/meta/main.yml
+++ b/deploy-nagios/meta/main.yml
@@ -1,14 +1,17 @@
+---
 galaxy_info:
   author: AeroGear
-  description: Provisioning of nagios for AeroGear digger
   company: AeroGear
+  description: Provisioning of nagios for AeroGear digger
   issue_tracker_url: https://issues.jboss.org/projects/AGDIGGER/issues
   license: license (Apache 2)
+  min_ansible_version: "2.2.0"
 
   platforms:
-  - name: deploy-nagios
+    - name: deploy-nagios
 
-  galaxy_tags: []
+  galaxy_tags:
+    - digger
 
 dependencies: 
   - { role: login }

--- a/provision-osx/meta/main.yml
+++ b/provision-osx/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: AeroGear
   description: Provisioning of macOS slave for AeroGear digger


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-16640

**Changes**
Added login dependency to all roles where it was required/missing (excluding osx roles)
- Standardised the layout of the `meta/main.yml` files for each role.

**Verification**
Run installer with the following tags:
- deploy-jenkins
- android-sdk
- configure-buildfarm
- deploy-nagios

_Expected result_
- login task should be run before(as a dependency) each of the roles