### PR TITLE
check stderr on jenkins restart

### DIFF
--- a/configure-buildfarm/handlers/main.yml
+++ b/configure-buildfarm/handlers/main.yml
@@ -18,4 +18,4 @@
   command: java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} restart
   listen: restart jenkins
   register: restart_cmd
-  failed_when: restart_cmd.rc != 0 and 'NullPointerException' not in restart_cmd.stdout
+  failed_when: restart_cmd.rc != 0 and 'NullPointerException' not in restart_cmd.stderr


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-16989

**What**
change stdout -> stderr

**Why**
Check was failing as the NullPointerException was visible in restart_cmd.stderr not restart_cmd.stdout

**Verification**
Run (against installed digger):
```
ansible-playbook -i inventory --tags=configure-buildfarm sample-build-playbook.yml
```

_Expected Result_
```
RUNNING HANDLER [configure-buildfarm : Restart Jenkins] ************************
changed: [local.feedhenry.io]
```
A refresh of Jenkins when at this point in the installer should result in a message confirming that Jenkins is indeed restarted. It should also be followed by a prompt for a login in Jenkins