### PR TITLE
 🐛 fix the default android debug key alias

### DIFF
--- a/android-sdk/templates/sample_cfg.j2
+++ b/android-sdk/templates/sample_cfg.j2
@@ -18,7 +18,7 @@ m2repository
 m2repository
 
 [keystore]
-alias=dummyalias
+alias=androiddebugkey
 name=AG
 unit=AeroGear 
 org=RedHat


### PR DESCRIPTION
The default android debug keystore needs to have the alias `androiddebugkey`