### PR TITLE
Rhmap  16781

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -75,12 +75,19 @@
     dest: /tmp/{{ config_file }}
     force: yes
 
+# Leaving in command below as comment as we can use this once the miniumum supported version of OpenShift is 3.5
+#-
+#  name: "Copy the Android SDK config file to the container"
+#  command: "oc cp --namespace={{ project_name }} /tmp/{{ config_file }} {{ android_sdk_podname }}:/opt/tools/{{ config_file }}"
+#  register: cp_cmd
+
 # install the config file
 -
   name: "Copy the Android SDK config file to the container"
-  command: "oc cp --namespace={{ project_name }} /tmp/{{ config_file }} {{ android_sdk_podname }}:/opt/tools/{{ config_file }}"
-  register: cp_cmd
-  failed_when: cp_cmd.stdout != ""
+  shell: "oc exec -i {{ android_sdk_podname }} --namespace={{ project_name }} -- bash -c 'cat > /opt/tools/{{ config_file }}' < /tmp/{{ config_file }}"
+-
+  name: "Set permission on the file"
+  shell: "oc exec -i {{ android_sdk_podname }} --namespace={{ project_name }} -- bash -c 'chmod 775 /opt/tools/{{ config_file }}'"
 
 -
   name: "Install the Android SDK"

--- a/vars/buildfarm.yml
+++ b/vars/buildfarm.yml
@@ -18,12 +18,11 @@ deployments:
   - name: "android-sdk"
     containers:
     - name: "android-sdk"
-      image: "docker.io/aerogear/android-sdk:dev"
+      image: "docker.io/aerogear/digger-android-sdk-image:latest"
   - name: "digger-nagios"
     containers:
     - name: "digger-nagios"
       image: "docker.io/aerogear/digger-nagios:dev"
-
 # the Jenkins username
 macos_user: jenkins
 


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-16781

**Changes**
- Update digger android-sdk image
- set image pull policy to Always (as we are using latest tag)
- Allow for copying the sample.cfg file to the Android Sdk pod in the case of OpenShift 3.3 and 3.4 where `oc cp` is not available

ping @matskiv  for review

**Verification Steps**
- Delete the android-sdk deployment-config on osm1
- Run
```
ansible-playbook -i osm1-inventory-file sample-build-playbook.yml --ask-vault-pass -e "project_name=aerogear-digger" --tags=login,android-sdk
```
The sample config file generated should be copied to `/opt/tools/` dir with the correct contents and the `androidctl sync` command should complete successfuly.

This should also be verified against an environment with OpenShift 3.4 installed if possible
