### PR TITLE
 ✨  add support for configuring android sdk via Ansible variables

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -74,6 +74,9 @@
     src: sample_cfg.j2
     dest: /tmp/{{ config_file }}
     force: yes
+  vars: 
+    components: "{{ android_sdk_components }}"
+    keystore: "{{ android_debug_keystore }}"
 
 # install the config file
 -

--- a/android-sdk/templates/sample_cfg.j2
+++ b/android-sdk/templates/sample_cfg.j2
@@ -1,29 +1,18 @@
-[base]
-tools
-platform-tools
+{% for comp in components|dictsort %}
 
-[platforms]
-android-24
-android-25
-
-[build-tools]
-25.0.1
-25.0.3
-
-[extras:google]
-google_play_services
-m2repository
-
-[extras:android]
-m2repository
+[{{ comp[0] }}]
+{% for compName in comp[1] %}
+{{ compName }}
+{% endfor %}
+{% endfor %}
 
 [keystore]
+name={{ keystore.name | default('AG') }}
+unit={{ keystore.unit | default('AeroGear') }} 
+org={{ keystore.org | default('RedHat') }}
+loc={{ keystore.loc | default('Waterford') }}
+state={{ keystore.state | default('WD') }}
+country={{ keystore.country | default('IRL') }}
 alias=androiddebugkey
-name=AG
-unit=AeroGear 
-org=RedHat
-loc=Waterford
-state=WD
-country=IRL
 storepass=android
 keypass=android

--- a/vars/buildfarm.yml
+++ b/vars/buildfarm.yml
@@ -35,3 +35,41 @@ project_name: aerogear-digger
 jenkins_route_protocol: https
 # max number of concurrent Android builds that are allowed
 concurrent_android_builds: 5
+# configurations for the Android SDK installation
+android_sdk_components:
+  base:
+    - tools
+    - platform-tools
+  platforms:
+    - android-26
+    - android-25
+    - android-24
+    - android-23
+    - android-22
+  build-tools:
+    - 26.0.1
+    - 26.0.0
+    - 25.0.3
+    - 25.0.2
+    - 25.0.1
+    - 25.0.0
+    - 24.0.3
+    - 23.0.3
+    - 23.0.2
+    - 23.0.1
+    - 23.0.0
+    - 22.0.1
+    - 22.0.0
+  "extras:google":
+    - google_play_services
+    - m2repository
+  "extras:android":
+    - m2repository
+# configurations for the default Android debug keystore
+android_debug_keystore:
+  name: AG
+  unit: AeroGear
+  org: RedHat
+  loc: Waterford
+  state: WD
+  country: IRL


### PR DESCRIPTION
To verify,

1. change the default android sdk configurations
2. Run
```
ansible-playbook -i <inventory file> sample-build-playbook.yml --tags=login,android-sdk -e "project_name=digger"
```
3. Wait for it to finish. rsh into the android sdk pod and you should see the android sdk configuration is updated to match the configuration. And it should be installed

ping @laurafitzgerald @PhilipGough @aidenkeating  for review.