### PR TITLE
Rhmap 16979

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -42,7 +42,7 @@
 
 -
   name: "Poll for Pods to become ready"
-  command: oc get pods --namespace={{ project_name }} --output jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}'
+  command: oc get dc android-sdk --namespace={{ project_name }} --output jsonpath='{.status.conditions[?(@.type=="Available")].status}'
   register: poll_result
   until: "'False' not in poll_result.stdout"
   retries: 60

--- a/deploy-jenkins/tasks/main.yml
+++ b/deploy-jenkins/tasks/main.yml
@@ -24,7 +24,7 @@
 
 -
   name: "Poll for Pods to become ready"
-  command: oc get pods --namespace={{ project_name }} --output jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}'
+  command: oc get dc jenkins --namespace={{ project_name }} --output jsonpath='{.status.conditions[?(@.type=="Available")].status}'
   register: poll_result
   until: "'False' not in poll_result.stdout"
   retries: 60

--- a/deploy-nagios/defaults/main.yml
+++ b/deploy-nagios/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # nagios environment variables
 smtp_server: localhost
 smtp_username: username

--- a/deploy-nagios/tasks/main.yml
+++ b/deploy-nagios/tasks/main.yml
@@ -32,7 +32,7 @@
     nagios_image_version: "{{ nagios_image_def[0][0].image }}"
 
 - 
-  name: "Update local nagios templae with image version and tag"
+  name: "Update local nagios template with image version and tag"
   template:
     src: nagios-template.j2
     dest: "{{ buildfarm_templates_dir }}/nagios-template.json"
@@ -75,7 +75,7 @@
   changed_when: nagios_create_result.rc == 0 or (nagios_create_result.rc == 1 and 'created' in nagios_create_result.stdout)
 -
   name: "Poll for Pods to become ready"
-  command: oc get pods --namespace={{ project_name }} --output jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}'
+  command: oc get dc nagios --namespace={{ project_name }} --output jsonpath='{.status.conditions[?(@.type=="Available")].status}'
   register: poll_result
   until: "'False' not in poll_result.stdout"
   retries: 60

--- a/deploy-nagios/templates/nagios-template.j2
+++ b/deploy-nagios/templates/nagios-template.j2
@@ -203,7 +203,7 @@
     {
       "name": "SMTP_USERNAME",
       "description": "SMTP username",
-      "value": "{{ smpt_username }}"
+      "value": "{{ smtp_username }}"
     },
     {
       "name": "SMTP_PASSWORD",


### PR DESCRIPTION
**JIRA**
https://issues.jboss.org/browse/RHMAP-16979

**Changes**
- Use dc template to check if pod is ready (android-sdk, jenkins & nagios)
- fix typo in nagios template

**Verification**
Command:
```
ansible-playbook -i ../rhmap-ansible/inventories/engineering/vagrant/vagrant-host sample-build-playbook.yml --tags=<tag>
```

- Trigger a failed deploy on one of the pods (i.e. bad container image or similar)
- Run command on fresh digger project for each tag: android-sdk, deploy-jenkins, deploy-nagios

_Expected Result_
Task should wait for each pod to come up correctly before moving on even in the case of a previous failed deployment.

Also requires a verification on the nagios env var change in template. All smtp variables should be populated correctly and no error during nagios tag.