### PR TITLE
RHMAP-16780 print login info

### DIFF
--- a/print-info/meta/main.yml
+++ b/print-info/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: AeroGear
+  company: AeroGear
+  description: Provisioning of nagios for AeroGear digger
+  issue_tracker_url: https://issues.jboss.org/projects/AGDIGGER/issues
+  license: license (Apache 2)
+  min_ansible_version: "2.2.0"
+
+  platforms:
+    - name: print-info
+
+  galaxy_tags:
+    - digger
+
+dependencies: 
+  - { role: login }

--- a/print-info/tasks/main.yml
+++ b/print-info/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+-
+  name: "Get jenkins url"
+  shell: "oc get route jenkins --namespace={{ project_name }} -o jsonpath='{.spec.host}'"
+  register: jenkins_route_output
+-
+  name: "Print Jenkins login information"
+  debug: msg="Your Jenkins instance is available at {{ jenkins_route_output.stdout }}.
+              Login credentials by default are username=admin and password=password.
+              Please note that the login credentials could have been changed if this is not a fresh installation."
+
+- block:
+    -
+      name: "Get Nagios url"
+      shell: "oc get route nagios --namespace={{ project_name }} -o jsonpath='{.spec.host}'"
+      register: nagios_route_output
+
+    -
+      name: "Get Nagios username"
+      shell: "oc get dc nagios --namespace={{ project_name }} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"NAGIOS_USER\")].value}'"
+      register: username_output
+
+    -
+      name: "Get Nagios password"
+      shell: "oc get dc nagios --namespace={{ project_name }} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"NAGIOS_PASSWORD\")].value}'"
+      register: password_output
+
+    -
+      name: "Print Nagios login information"
+      debug: msg="Your Nagios instance is available at {{ nagios_route_output.stdout }}.
+                  Credentials are username={{ username_output.stdout }} and password={{ password_output.stdout }} ."
+
+  rescue:
+    -
+      debug: msg="Unable to get Nagios route and/or credentials information. It is safe to ignore this problem if you are not using Nagios."

--- a/print-info/tasks/main.yml
+++ b/print-info/tasks/main.yml
@@ -4,11 +4,6 @@
   name: "Get jenkins url"
   shell: "oc get route jenkins --namespace={{ project_name }} -o jsonpath='{.spec.host}'"
   register: jenkins_route_output
--
-  name: "Print Jenkins login information"
-  debug: msg="Your Jenkins instance is available at {{ jenkins_route_output.stdout }}.
-              Login credentials by default are username=admin and password=password.
-              Please note that the login credentials could have been changed if this is not a fresh installation."
 
 - block:
     -
@@ -19,18 +14,32 @@
     -
       name: "Get Nagios username"
       shell: "oc get dc nagios --namespace={{ project_name }} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"NAGIOS_USER\")].value}'"
-      register: username_output
+      register: nagios_username_output
 
     -
       name: "Get Nagios password"
       shell: "oc get dc nagios --namespace={{ project_name }} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"NAGIOS_PASSWORD\")].value}'"
-      register: password_output
+      register: nagios_password_output
 
     -
-      name: "Print Nagios login information"
-      debug: msg="Your Nagios instance is available at {{ nagios_route_output.stdout }}.
-                  Credentials are username={{ username_output.stdout }} and password={{ password_output.stdout }} ."
+      # we cannot use the registered variables outside. as a workaround, we set these vars as facts.
+      set_fact:
+        nagios_route: "{{ nagios_route_output.stdout }}"
+        nagios_username: "{{ nagios_username_output.stdout }}"
+        nagios_password: "{{ nagios_password_output.stdout }}"
 
   rescue:
     -
       debug: msg="Unable to get Nagios route and/or credentials information. It is safe to ignore this problem if you are not using Nagios."
+
+-
+  name: "Print Jenkins login information"
+  debug: msg="Your Jenkins instance is available at {{ jenkins_route_output.stdout }}.
+              Login credentials by default are username=admin and password=password.
+              Please note that the login credentials could have been changed if this is not a fresh installation."
+
+-
+  name: "Print Nagios login information"
+  debug: msg="Your Nagios instance is available at {{ nagios_route }}.
+              Credentials are username={{ nagios_username }} and password={{ nagios_password }}"
+  when: nagios_route is defined

--- a/sample-build-playbook.yml
+++ b/sample-build-playbook.yml
@@ -34,3 +34,11 @@
     - {role: deploy-nagios, tags: deploy-nagios}
   vars_files:
     - "vars/buildfarm.yml"
+
+- name: "Print info"
+  hosts: master
+  remote_user: root
+  roles:
+    - {role: print-info, tags: print-info}
+  vars_files:
+    - "vars/buildfarm.yml"


### PR DESCRIPTION
## What
Print Jenkins and Nagios URLs and credentials.
## Verify
I used my local machine to issue commands on a cluster (OSM4).

Changed  "master" machine's url in `cluster_up_example` inventory to localhost. Then ran this command:

```
ansible-playbook -i cluster-up-example sample-build-playbook.yml --tags=print-info -e target="" -e master_url="..." -e oc_user="..." -e oc_password="..." -e project_name="..."
```
params:
* target: leave empty
* master_url: cluster login URL
* oc_user: OpenShift user
* oc_password: OpenShift password
* project_name: project name in OpenShift (e.g. "digger")

I saw these:

```
TASK [print-info : Print Jenkins login information] ****************************
ok: [127.0.0.1] => {
    "msg": "Your Jenkins instance is available at bla.bla.bla.com. Login credentials by default are username=admin and password=password. Please note that the login credentials could have been changed if this is not a fresh installation."
}

TASK [print-info : Get Nagios url] *********************************************
changed: [127.0.0.1]

TASK [print-info : Get Nagios username] ****************************************
changed: [127.0.0.1]

TASK [print-info : Get Nagios password] ****************************************
changed: [127.0.0.1]

TASK [print-info : Print Nagios login information] *****************************
ok: [127.0.0.1] => {
    "msg": "Your Nagios instance is available at bla.bla.bla.com. Credentials are username=nagiosadmin and password=hello ."
}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=13   changed=5    unreachable=0    failed=0   
```