### PR TITLE
Remove usage of proxy on local connections

### DIFF
--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -137,9 +137,6 @@
     url: "{{ item.archive }}"
     dest: /tmp/{{item.name}}.hpi
     mode: 775
-  environment:
-    http_proxy: "{{ proxy_url | default('') }}"
-    https_proxy: "{{ proxy_url | default('') }}"
   with_items: "{{ jenkins_plugins }}"
   when: plugins_output.stdout.find( item.name) != -1
   register: fetched_plugins

--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -39,13 +39,18 @@
     - config
     - security
 
+- name: "Get node public key"
+  shell: cat ~/.ssh/id_rsa.pub
+  register: public_key
+
 - pause:
     prompt: |
          Note: The following step is required. Playbook run will fail if skipped.
 
-         Jenkins was successfully installed. In order to configure Jenkins and continue with the installation please add the public key (~/.ssh/id_rsa.pub)
-         either from the master node (or from this machine if running ansible_connection=local) in the input box 'SSH Public Keys' at the link below:
+         Jenkins was successfully installed. In order to configure Jenkins and continue with the installation please add the below public key to the input box 'SSH Public Keys' at the link below:
          {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}/user/{{ jenkins_username | default("admin") }}/configure
+
+         {{ public_key.stdout }}
 
          After you've added your Public SSH key, hit enter to continue or ctrl + c to cancel.
   tags:

--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -43,7 +43,8 @@
     prompt: |
          Note: The following step is required. Playbook run will fail if skipped.
 
-         Jenkins was successfully installed. In order to configure Jenkins and continue with the installation please add your current public key (~/.ssh/id_rsa.pub) in the input box 'SSH Public Keys' at the link below:
+         Jenkins was successfully installed. In order to configure Jenkins and continue with the installation please add the public key (~/.ssh/id_rsa.pub)
+         either from the master node (or from this machine if running ansible_connection=local) in the input box 'SSH Public Keys' at the link below:
          {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}/user/{{ jenkins_username | default("admin") }}/configure
 
          After you've added your Public SSH key, hit enter to continue or ctrl + c to cancel.
@@ -55,7 +56,6 @@
 
 
 - name: "Get the jenkins client cli jar"
-  connection: local
   get_url:
     url: "{{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}/jnlpJars/jenkins-cli.jar"
     dest: /tmp/jenkins-cli.jar
@@ -73,7 +73,6 @@
     src: proxy-config.j2
     dest: "/tmp/proxy-config.groovy"
     force: yes
-  connection: local
   register: proxy_task
   when:
     - proxy_host is defined
@@ -87,7 +86,6 @@
   name: "Configure HTTP Proxy Settings"
   command: java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy /tmp/proxy-config.groovy
   when: not proxy_task|skipped
-  connection: local
   tags:
      - proxy
 
@@ -110,23 +108,28 @@
     src: kubernetes-plugin-config.j2
     dest: "/tmp/kubernetes-plugin-config.groovy"
     force: yes
-  connection: local
   tags:
     - config
 
 - name: "Configure Kubernetes plugin"
   shell: "java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy  /tmp/kubernetes-plugin-config.groovy"
-  connection: local
   register: output
   failed_when: output.stderr != ''
   tags:
      - config
 
+- name: "Copy configure plugins script"
+  copy:
+     src: "{{ groovy_script_dir }}/configure-plugins.groovy"
+     dest: "/tmp/configure-plugins.groovy"
+     mode: 0755
+  tags:
+    - config
+
 -
   name: "Get list of missing and unmet Jenkins plugins"
-  command: java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy {{ groovy_script_dir }}/configure-plugins.groovy  '{{ jenkins_plugins | to_json | replace('\n', '') }}'
+  command: java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy /tmp/configure-plugins.groovy  '{{ jenkins_plugins | to_json | replace('\n', '') }}'
   register: plugins_output
-  connection: local
   changed_when: false
   tags:
     - plugins
@@ -143,7 +146,6 @@
   with_items: "{{ jenkins_plugins }}"
   when: plugins_output.stdout.find( item.name) != -1
   register: fetched_plugins
-  connection: local
   notify:
     - remove plugins
   tags:
@@ -155,14 +157,21 @@
   with_items: "{{ jenkins_plugins }}"
   when: plugins_output.stdout.find( item.name) != -1
   register: installed_plugins
-  connection: local
   tags:
     - plugins
 
+
+- name: "Copy configure slave script"
+  copy:
+     src: "{{ groovy_script_dir }}/configure-plugins.groovy"
+     dest: "/tmp/configure-plugins.groovy"
+     mode: 0755
+  tags:
+    - config
+
 -
   name: "Enable Agent → Master Access Control"
-  command: java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy {{ groovy_script_dir }}/configure-slave-subsystem.groovy
-  connection: local
+  command: java -jar /tmp/jenkins-cli.jar -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}  groovy /tmp/configure-slave-subsystem.groovy
   register: master_slave_output
   changed_when: '"Done" in master_slave_output.stdout'
   tags:

--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -136,7 +136,10 @@
   get_url:
     url: "{{ item.archive }}"
     dest: /tmp/{{item.name}}.hpi
-    mode: 775
+    mode: 0775
+  environment:
+    http_proxy: "{{ proxy_url | default('') }}"
+    https_proxy: "{{ proxy_url | default('') }}"
   with_items: "{{ jenkins_plugins }}"
   when: plugins_output.stdout.find( item.name) != -1
   register: fetched_plugins

--- a/provision-osx/tasks/configure_buildfarm_node.yml
+++ b/provision-osx/tasks/configure_buildfarm_node.yml
@@ -29,7 +29,6 @@
     block:
     -
       name: Get the jenkins client cli jar
-      connection: local
       get_url:
         url: "{{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}/jnlpJars/jenkins-cli.jar"
         dest: /tmp/jenkins-cli.jar
@@ -79,7 +78,6 @@
       register: update_credential
       when: create_credential.rc != 0 and create_credential.stderr.find('No change') >= 0
     run_once: true
-    connection: local
 
   -
     authorized_key:
@@ -111,7 +109,6 @@
         executable: /bin/bash
       register: create_node
       when: create_node.rc != 0 and create_node.stderr.find('already exists') >= 0
-    connection: local
   when:
   - credential_private_key_path is defined
   - credential_private_key_path != ''

--- a/provision-osx/tasks/configure_buildfarm_node.yml
+++ b/provision-osx/tasks/configure_buildfarm_node.yml
@@ -36,9 +36,6 @@
         force: yes
         validate_certs: no
         mode: 0775
-      environment:
-        http_proxy: "{{ proxy_url | default('') }}"
-        https_proxy: "{{ proxy_url | default('') }}"
 
     -
       name: Retrieve provided private key
@@ -115,7 +112,7 @@
       register: create_node
       when: create_node.rc != 0 and create_node.stderr.find('already exists') >= 0
     connection: local
-  when: 
+  when:
   - credential_private_key_path is defined
   - credential_private_key_path != ''
   - credential_public_key_path is defined


### PR DESCRIPTION
I don't think we are supposed to use proxy for tasks with local connection.

I think it even causes errors like this:

> TASK [digger-installer/configure-buildfarm : Fetch required plugin] 
> failed: [osm4-oscp-5node-master1.skunkhenry.com] (item={u'version': u'2.15.4', u'name': u'config-file-provider', u'archive': u'https://updates.jenkins-ci.org/download/plugins/config-file-provider/2.15.4/config-file-provider.hpi'}) => {"failed": true, "item": {"archive": "https://updates.jenkins-ci.org/download/plugins/config-file-provider/2.15.4/config-file-provider.hpi", "name": "config-file-provider", "version": "2.15.4"}, "msg": "Failed to connect to updates.jenkins-ci.org at port 443: [Errno 110] Connection timed out"}