### PR TITLE
remove space

### DIFF
--- a/android-sdk/templates/sample_cfg.j2
+++ b/android-sdk/templates/sample_cfg.j2
@@ -6,7 +6,7 @@
 {% endfor %}
 {% endfor %}
 
- {# NOTE: the order of those entries are important, do not change the orders #}
+{# NOTE: the order of those entries are important, do not change the orders #}
 [keystore]
 alias=AndroidDebugKey
 name={{ keystore.name | default('AG') }}


### PR DESCRIPTION
**What**
Remove space

**Why**
Adds a space before '[keystore]' which causes a problem for androidctl

**Error**
```
AttributeError: 'NoneType' object has no attribute 'append'
```
Playbook fails