### PR TITLE
use status.availableReplicas for poll

### DIFF
--- a/android-sdk/tasks/main.yml
+++ b/android-sdk/tasks/main.yml
@@ -62,9 +62,10 @@
 
 -
   name: "Poll for Pods to become ready"
-  command: oc get dc android-sdk --namespace={{ project_name }} --output jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+  command: oc get dc android-sdk --namespace={{ project_name }} --output jsonpath='{.status.availableReplicas}'
   register: poll_result
-  until: "'False' not in poll_result.stdout"
+  until: poll_result.stdout == "1" and poll_result.stderr == ""
+  failed_when: '"error executing jsonpath" not in poll_result.stderr and poll_result.stdout != "1" and poll_result.stdout != "0"'
   retries: 60
   delay: 10
   tags:

--- a/deploy-jenkins/tasks/main.yml
+++ b/deploy-jenkins/tasks/main.yml
@@ -5,7 +5,7 @@
   name: "Update local jenkins-persistent template"
   template:
       src: jenkins-persistent-template.j2
-      dest: /tmp/jenkins-persistent-template.json
+      dest: "{{ buildfarm_templates_dir }}/jenkins-persistent-template.json"
 
 # Deploy Jenkins instance
 -
@@ -24,10 +24,10 @@
 
 -
   name: "Poll for Pods to become ready"
-  command: oc get dc jenkins --namespace={{ project_name }} --output jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+  command: oc get dc jenkins --namespace={{ project_name }} --output jsonpath='{.status.availableReplicas}'
   register: poll_result
-  until: "'False' not in poll_result.stdout"
+  until: poll_result.stdout == "1" and poll_result.stderr == ""
+  failed_when: '"error executing jsonpath" not in poll_result.stderr and poll_result.stdout != "1" and poll_result.stdout != "0"'
   retries: 60
   delay: 10
   when: jenkins_create_result|changed
-

--- a/deploy-nagios/tasks/main.yml
+++ b/deploy-nagios/tasks/main.yml
@@ -73,11 +73,13 @@
   failed_when:
     - nagios_create_result.stderr and nagios_create_result.stderr != '' and 'already exists' not in nagios_create_result.stderr
   changed_when: nagios_create_result.rc == 0 or (nagios_create_result.rc == 1 and 'created' in nagios_create_result.stdout)
+
 -
   name: "Poll for Pods to become ready"
-  command: oc get dc nagios --namespace={{ project_name }} --output jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+  command: oc get dc nagios --namespace={{ project_name }} --output jsonpath='{.status.availableReplicas}'
   register: poll_result
-  until: "'False' not in poll_result.stdout"
+  until: poll_result.stdout == "1" and poll_result.stderr == ""
+  failed_when: '"error executing jsonpath" not in poll_result.stderr and poll_result.stdout != "1" and poll_result.stdout != "0"'
   retries: 60
   delay: 10
   when: nagios_create_result|changed


### PR DESCRIPTION
**What**
Use `.status.availableRecplicas` in poll for pod check 

**Why**
`.status.conditions...` is was not used in OpenShift 3.3 deployment configs

**Verification**
This change needs to be tested against cluster running both 3.3 and 3.5

Command to Run:
```
ansible-playbook -i ../rhmap-ansible/inventories/engineering/osm1/osm1-hosts sample-build-playbook.yml --skip-tags=osx-provision -e "project_name=digger-poll-14" --ask-vault-pass
```
Monitor the output and see that the poll will wait for the pods to come up in all cases (nagios, jenkins, android-sdk) on both versions (3.3 and 3.5)
