### PR TITLE
Run java check remotly

### DIFF
--- a/sample-build-playbook.yml
+++ b/sample-build-playbook.yml
@@ -1,13 +1,11 @@
 ---
 
 - name: "Run initial minimum requirement checks"
-  hosts: localhost
-  remote_user: root
+  hosts: master
   tasks:
     -
       name: "Check Java is installed on path of local machine"
       command: which java
-      connection: local
 
 - name: "Deploy Digger"
   hosts: master


### PR DESCRIPTION
Since #51 PR we are no longer using java locally, but we need it on master node. Updating per-requisite check to reflect this.  