### PR TITLE
android sdk constraint-layout packages

### DIFF
--- a/android-sdk/vars/main.yml
+++ b/android-sdk/vars/main.yml
@@ -30,6 +30,14 @@ android_sdk_components:
     - m2repository
   "extras:android":
     - m2repository
+  "extras:m2repository:com:android:support:constraint:constraint-layout":
+    - 1.0.0
+    - 1.0.1
+    - 1.0.2
+  "extras:m2repository:com:android:support:constraint:constraint-layout-solver":
+    - 1.0.0
+    - 1.0.2
+
 # configurations for the default Android debug keystore
 android_debug_keystore:
   name: AG


### PR DESCRIPTION
Adds "constraint-layout" android sdk packages into vars file.

Verification:

Deploy the new constraint-layout packages by running:

```
ansible-platbook -i inventory.cfg sample-build-playbook.yml --tags=android-sdk
```

Test it by building the android app from this repo: [https://github.com/wojta/_constraintlayout](https://github.com/wojta/_constraintlayout)

ping @matskiv  