### PR TITLE
removed .bash_profile reference from .profile file

### DIFF
--- a/provision-osx/tasks/configure_base_system.yml
+++ b/provision-osx/tasks/configure_base_system.yml
@@ -17,9 +17,3 @@
   lineinfile:
     dest: ~/.bash_profile
     line: "export LANG={{ buildfarm_lang_env_var }}"
-
--
-  name: Configure profile file
-  lineinfile:
-    dest: ~/.profile
-    line: "source ~/.bash_profile"


### PR DESCRIPTION
I have run the base system playbook in our osx machine, jenkins ssh user still works + LANG env var is set as well.

ping @wei-lee 