### PR TITLE
[AGDIGGER-143] Add role for git installation

### DIFF
--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -4,6 +4,11 @@
 
 remote_tmp_dir: /tmp
 
+git_install_url: https://netix.dl.sourceforge.net/project/git-osx-installer/git-2.13.1-intel-universal-mavericks.dmg
+git_install_dmg_name: git-2.13.1-intel-universal-mavericks.dmg
+git_install_volume_name: git-installer-volume
+git_install_pkg_name: git-2.13.1-intel-universal-mavericks.pkg
+
 nvm_install_url: https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh
 nvm_install_file_name: install-nvm.sh
 
@@ -32,7 +37,7 @@ homebrew_packages:
 - name: gpg
 - name: grep
 - name: jq
-  
+
 homebrew_repo: https://github.com/Homebrew/brew
 homebrew_version: "1.2.3"
 

--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -4,7 +4,7 @@
 
 remote_tmp_dir: /tmp
 
-git_install_url: https://netix.dl.sourceforge.net/project/git-osx-installer/git-2.13.1-intel-universal-mavericks.dmg
+git_install_url: https://sourceforge.net/projects/git-osx-installer/files/git-2.13.1-intel-universal-mavericks.dmg/download?use_mirror=autoselect
 git_install_dmg_name: git-2.13.1-intel-universal-mavericks.dmg
 git_install_volume_name: git-installer-volume
 git_install_pkg_name: git-2.13.1-intel-universal-mavericks.pkg

--- a/provision-osx/tasks/install_git.yml
+++ b/provision-osx/tasks/install_git.yml
@@ -4,6 +4,7 @@
   name: Check if git is installed
   command: git --version
   failed_when: no
+  changed_when: False
   register: git_installed
 
 -

--- a/provision-osx/tasks/install_git.yml
+++ b/provision-osx/tasks/install_git.yml
@@ -1,0 +1,39 @@
+---
+
+-
+  name: Check if git is installed
+  command: git --version
+  failed_when: no
+  register: git_installed
+
+-
+  name: Download git package
+  get_url:
+    url: "{{git_install_url}}"
+    dest: "{{remote_tmp_dir}}/{{git_install_dmg_name}}"
+  when: git_installed.rc != 0
+  environment:
+    http_proxy: "{{ proxy_url | default('') }}"
+    https_proxy: "{{ proxy_url | default('') }}"
+
+-
+  name: Attach git installation dmg
+  command: "hdiutil attach {{remote_tmp_dir}}/{{git_install_dmg_name}} -mountpoint {{remote_tmp_dir}}/{{git_install_volume_name}}"
+  when: git_installed.rc != 0
+
+-
+  name: Install git package
+  command: "installer -package {{remote_tmp_dir}}/{{git_install_volume_name}}/{{git_install_pkg_name}} -target /"
+  become: yes
+  when: git_installed.rc != 0
+
+-
+  name : Detach git installation dmg
+  command: hdiutil detach {{remote_tmp_dir}}/{{git_install_volume_name}}/
+  when: git_installed.rc != 0
+
+-
+  name: Check that git was installed correctly
+  command: git --version
+  when: git_installed.rc != 0
+

--- a/provision-osx/tasks/main.yml
+++ b/provision-osx/tasks/main.yml
@@ -3,9 +3,12 @@
 - include: configure_base_system.yml
   tags: osx_base_system
 
+- include: install_git.yml
+  tags: osx_install_git
+
 - include: install_homebrew.yml
   tags: osx_install_homebrew
-  
+
 - include: install_ruby.yml
   tags: osx_install_ruby
 


### PR DESCRIPTION
**Why:** we are using git to install homebrew, but git is not available on clean OSX installation. 

JIRA: https://issues.jboss.org/browse/AGDIGGER-143