### PR TITLE
Jenkins storage capacity aligned with template default

### DIFF
--- a/pv-sample-templates/jenkins/sample-pv-gluster.json
+++ b/pv-sample-templates/jenkins/sample-pv-gluster.json
@@ -6,7 +6,7 @@
   },
   "spec": {
     "capacity": {
-      "storage": "10Gi"
+      "storage": "40Gi"
     },
     "accessModes": [
       "ReadWriteOnce"

--- a/pv-sample-templates/jenkins/sample-pv-nfs.json
+++ b/pv-sample-templates/jenkins/sample-pv-nfs.json
@@ -6,7 +6,7 @@
   },
   "spec": {
     "capacity": {
-      "storage": "10Gi"
+      "storage": "40Gi"
     },
     "accessModes": [
       "ReadWriteOnce"

--- a/pv-sample-templates/jenkins/sample-pv.json
+++ b/pv-sample-templates/jenkins/sample-pv.json
@@ -6,7 +6,7 @@
   },
   "spec": {
     "capacity": {
-      "storage": "10Gi"
+      "storage": "40Gi"
     },
     "accessModes": [
       "ReadWriteOnce"


### PR DESCRIPTION
**Motivation**

Jenkins storage capacity default value is set to 40GiB in template (https://github.com/aerogear/digger-installer/blob/master/deploy-jenkins/templates/jenkins-persistent-template.j2#L283). It is better for the sample pv files that might be used for pv creation to use the same value.