### PR TITLE
cocopods cronjob

### DIFF
--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -95,3 +95,6 @@ proxy_ctx:
 
 buildfarm_lang_env_var: "en_US.UTF-8"
 buildfarm_path_env_var: "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+cocoapods_update_hour_loop: 3
+pod_update_bin_path: /usr/local/bin/cocoapods-update-repo

--- a/provision-osx/files/cocoapods-update-repo
+++ b/provision-osx/files/cocoapods-update-repo
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+REPOS_PATH=".cocoapods/repos"
+FOLDER="$HOME/$REPOS_PATH"
+ERROR_LOG_FILE="$HOME/.cocoapods/cocoapods-error.log"
+SUCCESS_LOG_FILE="$HOME/.cocoapods/cocoapods-success.log"
+
+for dir in `ls $FOLDER`;
+do
+    (
+      cd $FOLDER/$dir;
+      git fetch origin --quiet;
+      git reset --hard origin/master --quiet;
+    )
+    if [ $? -eq 0 ]; then
+      if [ -f $ERROR_LOG_FILE ] ; then
+        rm $ERROR_LOG_FILE
+      fi
+      touch $SUCCESS_LOG_FILE
+    else
+      touch $ERROR_LOG_FILE
+    fi
+done

--- a/provision-osx/tasks/cocoapods.yml
+++ b/provision-osx/tasks/cocoapods.yml
@@ -36,3 +36,18 @@
     LANG: "{{ buildfarm_env_lang.stdout }}"
     http_proxy: "{{ proxy_url | default('') }}"
     https_proxy: "{{ proxy_url | default('') }}"
+
+-
+  name: Copy cocoapods update script
+  copy:
+     src: "cocoapods-update-repo"
+     dest: "{{pod_update_bin_path}}"
+     mode: 0755
+
+-
+  name: Set cocoapods cron job
+  cron:
+    name: "cocoapods cron job"
+    minute: '0'
+    hour: "*/{{ cocoapods_update_hour_loop }}"
+    job: "{{ pod_update_bin_path }} > /dev/null"


### PR DESCRIPTION
## Changes
Adds cocoapods update script as a cron job.

## Verification steps

Run the installer using the osx tag:

```
ansible-playbook -i inventory.cfg playbook.yml --tags=osx_cocoapods --ask-become-pass
```

After running the playbook:

* there should be a bash script in `/usr/local/bin/cocoapods-update-repo`  with exec permissions
* running `crontab -e` should list the above script
* running `cocoapods-upate-repo` should update the machine's cocoapods repository and create a log file in `$HOME/.cocoapods` (`cocoapods-success.log` or `cocoapods-error.log`)