### PR TITLE
Nagios check ignore unknown

### DIFF
--- a/deploy-nagios/tasks/main.yml
+++ b/deploy-nagios/tasks/main.yml
@@ -142,7 +142,6 @@
   register: nagios_result
   failed_when: False
 
-
 -
   name: "Verify Nagios dashboard is green, fail otherwise"
   shell: echo {{ item }}
@@ -151,7 +150,19 @@
   failed_when:
     - "'critical' in nagios_dashboard.stdout or 'warning' in nagios_dashboard.stdout or 'unknown' in nagios_dashboard.stdout "
   changed_when: False
+  when:
+     - target is defined
+     - "'cluster' in target"
 
+-
+  name: "Verify Nagios dashboard is green, fail otherwise"
+  shell: echo {{ item }}
+  register: nagios_dashboard
+  with_items: "{{ nagios_result.stdout_lines }}"
+  failed_when:
+    - "'critical' in nagios_dashboard.stdout or 'warning' in nagios_dashboard.stdout"
+  changed_when: False
+  when: target is undefined or (target is defined and "'cluster' not in target")
 
 - debug: var=nagios_dashboard.stdout_lines
   when: nagios_dashboard|failed

--- a/deploy-nagios/tasks/main.yml
+++ b/deploy-nagios/tasks/main.yml
@@ -150,9 +150,7 @@
   failed_when:
     - "'critical' in nagios_dashboard.stdout or 'warning' in nagios_dashboard.stdout or 'unknown' in nagios_dashboard.stdout "
   changed_when: False
-  when:
-     - target is defined
-     - "'cluster' in target"
+  when: "target is undefined or (target is defined and 'cluster' not in target)"
 
 -
   name: "Verify Nagios dashboard is green, fail otherwise"
@@ -160,9 +158,9 @@
   register: nagios_dashboard
   with_items: "{{ nagios_result.stdout_lines }}"
   failed_when:
-    - "'critical' in nagios_dashboard.stdout or 'warning' in nagios_dashboard.stdout"
+    - "'critical' in nagios_dashboard.stdout"
   changed_when: False
-  when: target is undefined or (target is defined and "'cluster' not in target")
+  when: "target is defined and 'cluster' in target"
 
 - debug: var=nagios_dashboard.stdout_lines
   when: nagios_dashboard|failed

--- a/vars/buildfarm.yml
+++ b/vars/buildfarm.yml
@@ -22,7 +22,7 @@ deployments:
   - name: "nagios"
     containers:
     - name: "nagios"
-      image: "docker.io/aerogear/digger-nagios:dev"
+      image: "docker.io/aerogear/digger-nagios:v1.0"
 # the Jenkins username
 macos_user: jenkins
 


### PR DESCRIPTION
**What**
Update the nagios image to a v1.0
Change check on cluster up to ignore unknown

**Why**
On MAC(and possibly Windows) using oc cluster up the cgroups checks are not working which means that the installer is failing. Ignore cases where unknown are returned

@PhilipGough 
