### PR TITLE
xcode 9 install

### DIFF
--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -59,6 +59,7 @@ homebrew_taps:
 
 xcode_versions:
 - '8.3.3'
+- '9'
 
 xcode_default_version: "{{ xcode_versions[0] }}"
 

--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -58,7 +58,6 @@ homebrew_taps:
 - caskroom/cask
 
 xcode_versions:
-- '8.3.3'
 - '9'
 
 xcode_default_version: "{{ xcode_versions[0] }}"


### PR DESCRIPTION
# Changes

Adds Xcode 9 in provision-osx role.

## Verification steps

* Run  the installer targeting a mac machine using the "osx_install_xcode" tag
* Ssh into the machine and check the `/Applications` folder, it should contain a Xcode-9.app application folder